### PR TITLE
Support for VMware Photon OS

### DIFF
--- a/base/aac-base.install
+++ b/base/aac-base.install
@@ -72,7 +72,7 @@ function findos() {
 		VERSION_ID=`awk '{print $3}' /etc/debian-release | awk -F. '{print $1}'`
 	elif [ -e /etc/photon-release ]
 	then
-		theos="photon"
+		theos="VMware Photon OS"
 		VERSION_ID=`awk '{print $4}' /etc/photon-release | awk -F ' '  '{print $1}'`
 	else
 		# Mac OS
@@ -92,7 +92,7 @@ function findos() {
 function checkdep() {
 	dep=$1
 	needdep=0
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"VMware Photon OS" ]
 	then
 		rpm -q $dep >& /dev/null
 		if [ $? -ne 0 ]
@@ -130,7 +130,7 @@ function installdep() {
 	then
 		installopts=$1
 	fi
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"VMware Photon OS" ]
 	then
 		if [ Z"$INSTALL" != Z"" ] || [ Z"$DEVEL" != Z"" ]
 		then
@@ -626,7 +626,7 @@ RPMLIST=''
 if [ $ansible -ne 1 ]
 then
 	echo "Getting RPMLIST"
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"VMware Photon OS" ]
 	then
 		RPMLIST=`rpm -qa`
 	elif [ Z"$theos" = Z"debian" ] || [ Z"$theos" = Z"ubuntu" ]

--- a/base/aac-base.install
+++ b/base/aac-base.install
@@ -70,7 +70,6 @@ function findos() {
 	then
 		theos=`cut -d' ' -f1 < /etc/debian-release | tr [:upper:] [:lower:]`
 		VERSION_ID=`awk '{print $3}' /etc/debian-release | awk -F. '{print $1}'`
-	else
 	elif [ -e /etc/photon-release ]
 	then
 		theos="photon"

--- a/base/aac-base.install
+++ b/base/aac-base.install
@@ -4,7 +4,7 @@
 #
 # Create a Base Install to use Ansible for further installs
 #
-# Target: CentOS/RHEL 7/Photon/Debian/Ubuntu/MacOS
+# Target: CentOS/RHEL 7/Debian/Ubuntu/MacOS
 #
 ###
 VERSIONID="2.1.3"

--- a/base/aac-base.install
+++ b/base/aac-base.install
@@ -4,7 +4,7 @@
 #
 # Create a Base Install to use Ansible for further installs
 #
-# Target: CentOS/RHEL 7/Debian/Ubuntu/MacOS
+# Target: CentOS/RHEL 7/Photon/Debian/Ubuntu/MacOS
 #
 ###
 VERSIONID="2.1.3"
@@ -71,6 +71,11 @@ function findos() {
 		theos=`cut -d' ' -f1 < /etc/debian-release | tr [:upper:] [:lower:]`
 		VERSION_ID=`awk '{print $3}' /etc/debian-release | awk -F. '{print $1}'`
 	else
+	elif [ -e /etc/photon-release ]
+	then
+		theos="photon"
+		VERSION_ID=`awk '{print $4}' /etc/photon-release | awk -F ' '  '{print $1}'`
+	else
 		# Mac OS
 		uname -a | grep Darwin  >& /dev/null
 		if [ $? -eq 0 ]
@@ -88,7 +93,7 @@ function findos() {
 function checkdep() {
 	dep=$1
 	needdep=0
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
 	then
 		rpm -q $dep >& /dev/null
 		if [ $? -ne 0 ]
@@ -126,7 +131,7 @@ function installdep() {
 	then
 		installopts=$1
 	fi
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
 	then
 		if [ Z"$INSTALL" != Z"" ] || [ Z"$DEVEL" != Z"" ]
 		then
@@ -622,7 +627,7 @@ RPMLIST=''
 if [ $ansible -ne 1 ]
 then
 	echo "Getting RPMLIST"
-	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ]
+	if [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
 	then
 		RPMLIST=`rpm -qa`
 	elif [ Z"$theos" = Z"debian" ] || [ Z"$theos" = Z"ubuntu" ]

--- a/base/ansible/aac-base-tz.yaml
+++ b/base/ansible/aac-base-tz.yaml
@@ -136,7 +136,7 @@
      - name: Set Facts
        set_fact:
          set_time: ntp
-       when: ansible_os_family == "Debian"
+       when: ((ansible_os_family == "Debian") or (ansible_os_family == "VMware Photon OS"))
 
      - name: Set Facts
        set_fact:

--- a/base/scripts/aac-base.install.vsm
+++ b/base/scripts/aac-base.install.vsm
@@ -35,11 +35,11 @@ function vsm() {
 	if [ Z"$theos" = Z"debian" ] || [ Z"$theos" = Z"ubuntu" ]
 	then
 		checkdep xml-twig-tools
-	elif [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
+	elif [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"VMware Photon OS" ]
 	then
 		checkdep perl-XML-Twig
 	fi
-	if [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
+	if [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"VMware Photon OS" ]
 	then
 		INSTALL="$INSTALL $FPYTHON"
 	else

--- a/base/scripts/aac-base.install.vsm
+++ b/base/scripts/aac-base.install.vsm
@@ -35,11 +35,11 @@ function vsm() {
 	if [ Z"$theos" = Z"debian" ] || [ Z"$theos" = Z"ubuntu" ]
 	then
 		checkdep xml-twig-tools
-	elif [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ]
+	elif [ Z"$theos" = Z"centos" ] || [ Z"$theos" = Z"redhat" ] || [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
 	then
 		checkdep perl-XML-Twig
 	fi
-	if [ Z"$theos" = Z"fedora" ]
+	if [ Z"$theos" = Z"fedora" ] || [ Z"$theos" = Z"photon" ]
 	then
 		INSTALL="$INSTALL $FPYTHON"
 	else


### PR DESCRIPTION
Hi, as discussed yesterday, some support for VMware Photon OS could be nice.

The pull request content is incomplete. Here some other findings:

- I didn't dare to update any version number

- ansible_os_family shows up as "VMware Photon OS"
```
root@Photon3 [ ~ ]# ansible localhost -m setup | grep -i "photon"
[WARNING]: No inventory was parsed, only implicit localhost is available
        "ansible_distribution": "VMware Photon OS",
        "ansible_fqdn": "Photon3.0rev2",
        "ansible_hostname": "Photon3",
            "codename": "Photon",
            "description": "VMware Photon OS 3.0",
            "id": "VMware Photon OS",
        "ansible_nodename": "Photon3.0rev2",
        "ansible_os_family": "VMware Photon OS"
```

- I've installed some packages manually: ```tdnf install -y ansible python-pip ntp```.

- ```install.sh``` stops with
```
TASK [Package Facts] *******************************************************************************************************************************************************************************************************************************
[WARNING]: Found "rpm" but Failed to import the required Python library (rpm) on Photon3.0rev2's Python /bin/python2. Please read module documentation and install in the appropriate location

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not detect a supported package manager from the following list: ['portage', 'rpm', 'pkg', 'apt'], or the required Python library is not installed. Check warnings for details."}
```

- The run solely was processed on a PhotonOS 3.0rev2 box.

Hope this helps for a next step in VMware Photon OS support.